### PR TITLE
Add React Native skeleton with Health Connect module

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AppNavigator } from './src/navigation';
+
+const App = () => <AppNavigator />;
+
+export default App;

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # Athena
 
-Aplikacija u razvoju.
+Minimalni kostur mobilne aplikacije za pracenje epileptickih napada. Projekat sadrzi dve osnovne stranice i most za pristup Google Health Connect podacima.
 
-## Opis
+## Struktura
+- **Evidencija** – ekran za evidenciju napada
+- **Test** – ekran sa dugmetom za preuzimanje podataka iz Health Connect-a
 
-Ovaj projekat je u fazi planiranja i razvoja.
+## Pokretanje
 
-## Instalacija
+```bash
+npm install
+npm run android # ili npm run ios
+```
 
-Instrukcije za instalaciju će biti dodate kasnije.
+## Testiranje
 
-## Korišćenje
-
-Instrukcije za korišćenje će biti dodate kasnije.
-
-## Licenca
-
-Ovaj projekat je pod [MIT licencom](LICENSE). 
+```
+npm test
+```

--- a/android/app/src/main/java/com/athena/HealthConnectModule.kt
+++ b/android/app/src/main/java/com/athena/HealthConnectModule.kt
@@ -1,0 +1,18 @@
+package com.athena
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise
+
+class HealthConnectModule(private val reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = "HealthConnectModule"
+
+    @ReactMethod
+    fun fetchAllData(promise: Promise) {
+        // TODO: Implement fetching all Health Connect data
+        promise.resolve("Health data placeholder")
+    }
+}

--- a/android/app/src/main/java/com/athena/HealthConnectPackage.kt
+++ b/android/app/src/main/java/com/athena/HealthConnectPackage.kt
@@ -1,0 +1,14 @@
+package com.athena
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.bridge.NativeModule
+
+class HealthConnectPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(HealthConnectModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
+}

--- a/android/app/src/main/java/com/athena/MainActivity.kt
+++ b/android/app/src/main/java/com/athena/MainActivity.kt
@@ -1,0 +1,7 @@
+package com.athena
+
+import com.facebook.react.ReactActivity
+
+class MainActivity : ReactActivity() {
+    override fun getMainComponentName(): String = "Athena"
+}

--- a/android/app/src/main/java/com/athena/MainApplication.kt
+++ b/android/app/src/main/java/com/athena/MainApplication.kt
@@ -1,0 +1,30 @@
+package com.athena
+
+import android.app.Application
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.shell.MainReactPackage
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+    private val mReactNativeHost: ReactNativeHost = object : ReactNativeHost(this) {
+        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
+
+        override fun getPackages(): List<ReactPackage> =
+            listOf(
+                MainReactPackage(),
+                HealthConnectPackage()
+            )
+
+        override fun getJSMainModuleName() = "index"
+    }
+
+    override fun getReactNativeHost(): ReactNativeHost = mReactNativeHost
+
+    override fun onCreate() {
+        super.onCreate()
+        SoLoader.init(this, false)
+    }
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Athena",
+  "displayName": "Athena"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "athena",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.33",
+    "@types/react-native": "^0.73.12",
+    "typescript": "^5.3.3",
+    "jest": "^29.6.1",
+    "react-test-renderer": "18.2.0"
+  }
+}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import Evidencija from '../screens/Evidencija';
+import Test from '../screens/Test';
+
+const Stack = createNativeStackNavigator();
+
+export const AppNavigator = () => (
+  <NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Evidencija" component={Evidencija} />
+      <Stack.Screen name="Test" component={Test} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);

--- a/src/screens/Evidencija.tsx
+++ b/src/screens/Evidencija.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const Evidencija = () => (
+  <View style={styles.container}>
+    <Text style={styles.text}>Evidencija napada</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 20 },
+});
+
+export default Evidencija;

--- a/src/screens/Test.tsx
+++ b/src/screens/Test.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Button, NativeModules } from 'react-native';
+
+const { HealthConnectModule } = NativeModules;
+
+type DataState = string | null;
+
+const Test = () => {
+  const [data, setData] = useState<DataState>(null);
+
+  const fetchData = async () => {
+    try {
+      const result = await HealthConnectModule.fetchAllData();
+      setData(JSON.stringify(result));
+    } catch (e) {
+      setData('Greška pri preuzimanju podataka');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Preuzmi Health Connect podatke" onPress={fetchData} />
+      {data && <Text style={styles.text}>{data}</Text>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 16 },
+  text: { marginTop: 16 },
+});
+
+export default Test;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2017"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize React Native project structure with TypeScript
- add navigation with Evidencija and Test screens
- implement Kotlin bridge placeholder for Health Connect data
- document setup and usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5b11dd04832fac0e71e242894a8e